### PR TITLE
Use Jetty 9 instead of 11 for servlet compatibility.

### DIFF
--- a/portfolio/pom.xml
+++ b/portfolio/pom.xml
@@ -12,7 +12,7 @@
     <maven.compiler.source>11</maven.compiler.source>
     <maven.compiler.target>11</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <jetty.version>11.0.0</jetty.version>
+    <jetty.version>9.4.31.v20200723</jetty.version>
 
     <!-- Project-specific properties -->
     <exec.mainClass>com.google.sps.ServerMain</exec.mainClass>


### PR DESCRIPTION
Minor fix to use Jetty 9 instead of 11 for servlets. Jetty 11 is not compatible with servlets.